### PR TITLE
Ignore luaunit tests

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -66,7 +66,10 @@ do -- Assume Factorio Control Stage as Default
         '**/trailer/',
 
         --Ignore love Includes
-        '**/love/includes/'
+        '**/love/includes/',
+
+        --Ignore luaunit 'executable'--
+        '**/luaunit.lua'
     }
 end
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -28,7 +28,7 @@
 ------------------------------------------------------------------------------]]
 local LINE_LENGTH = false
 
-local IGNORE = {'21./%w+_$', '21./^_[_%w]+$', '213/^%a$', '213/index', '213/key'}
+local IGNORE = {'21./%w+_$', '21./^_[_%w]+$', '213/^%a$', '213/index', '213/key', '[Tt]est[%w_]+'}
 
 -- These globals are not available to the factorio API
 local NOT_GLOBALS = {'coroutine', 'io', 'socket', 'dofile', 'loadfile'}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -28,7 +28,7 @@
 ------------------------------------------------------------------------------]]
 local LINE_LENGTH = false
 
-local IGNORE = {'21./%w+_$', '21./^_[_%w]+$', '213/^%a$', '213/index', '213/key', '[Tt]est[%w_]+'}
+local IGNORE = {'21./%w+_$', '21./^_[_%w]+$', '213/^%a$', '213/index', '213/key', '11[12]/[Tt]est[%w_]+'}
 
 -- These globals are not available to the factorio API
 local NOT_GLOBALS = {'coroutine', 'io', 'socket', 'dofile', 'loadfile'}


### PR DESCRIPTION
First of all, thank you for putting the effort in making luacheck configuration compatible with Factorio!

I ~am~ was struggling getting some logics correct, so I made some unit tests to prevent regressions while fixing some other part.
But my (global) test functions give warnings by luacheck, so I borrowed the ignore from [luaunit config](https://github.com/bluebird75/luaunit/blob/master/.luacheckrc#L10)

Please consider accepting this PR, so I can revert using your repo again.