### PR TITLE
Add "read_only = false" for settings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -200,8 +200,8 @@ do -- Factorio STDs--
                 fields = {
                     'get_player_settings',
                     startup = {other_fields = true},
-                    global = {other_fields = true},
-                    player = {other_fields = true},
+                    global = {other_fields = true, read_only = false},
+                    player = {other_fields = true, read_only = false},
                     get = {read_only = false}, -- stdlib added
                     get_startup = {read_only = false} -- stdlib added
                 }


### PR DESCRIPTION
https://lua-api.factorio.com/latest/LuaSettings.html#LuaSettings.global

> Even though these are marked as read-only, they can be changed by overwriting individual ModSetting tables in the custom table. Mods can only change their own settings. Using the in-game console, all global settings can be changed.